### PR TITLE
[iam] Add IAM protocol V2

### DIFF
--- a/proto/iamanager/v2/iamanagercommon.proto
+++ b/proto/iamanager/v2/iamanagercommon.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package iamanager.v2;
+
+message Permissions {
+    map<string, string> permissions = 1;
+}
+
+message Users {
+    repeated string users = 1;
+}

--- a/proto/iamanager/v2/iamanagerprotected.proto
+++ b/proto/iamanager/v2/iamanagerprotected.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+import "iamanager/v2/iamanagercommon.proto";
+
+package iamanager.v2;
+
+service IAMProtectedService {
+    rpc SetOwner(SetOwnerRequest) returns (google.protobuf.Empty) {}
+    rpc Clear(ClearRequest) returns (google.protobuf.Empty) {}
+    rpc CreateKey(CreateKeyRequest) returns (CreateKeyResponse) {}
+    rpc ApplyCert(ApplyCertRequest) returns (ApplyCertResponse) {}
+    rpc EncryptDisk(EncryptDiskRequest) returns (google.protobuf.Empty) {}
+    rpc FinishProvisioning(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+    rpc SetUsers(Users) returns (google.protobuf.Empty) {}
+    rpc RegisterService(RegisterServiceRequest) returns (RegisterServiceResponse) {}
+    rpc UnregisterService(UnregisterServiceRequest) returns (google.protobuf.Empty) {}
+}
+
+message ClearRequest {
+    string type = 1;
+}
+
+message SetOwnerRequest {
+    string type     = 1;
+    string password = 2;
+}
+
+message CreateKeyRequest {
+    string type     = 1;
+    string password = 2;
+}
+
+message CreateKeyResponse {
+    string type = 1;
+    string csr  = 2;
+}
+
+message ApplyCertRequest {
+    string type = 1;
+    string cert = 2;
+}
+
+message ApplyCertResponse {
+    string type     = 1;
+    string cert_url = 2;
+}
+
+message RegisterServiceRequest {
+    string service_id                    = 1;
+    map<string, Permissions> permissions = 2;
+}
+
+message RegisterServiceResponse {
+    string secret = 1;
+}
+
+message UnregisterServiceRequest {
+    string service_id = 1;
+}
+
+message EncryptDiskRequest {
+    string password = 1;
+}

--- a/proto/iamanager/v2/iamanagerpublic.proto
+++ b/proto/iamanager/v2/iamanagerpublic.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+import "iamanager/v2/iamanagercommon.proto";
+
+package iamanager.v2;
+
+service IAMPublicService {
+    rpc GetSystemInfo(google.protobuf.Empty) returns (SystemInfo) {}
+    rpc GetCertTypes(google.protobuf.Empty) returns (CertTypes) {}
+    rpc GetCert(GetCertRequest) returns (GetCertResponse) {}
+    rpc GetPermissions(PermissionsRequest) returns (PermissionsResponse) {}
+    rpc GetUsers(google.protobuf.Empty) returns (Users) {}
+    rpc SubscribeUsersChanged(google.protobuf.Empty) returns (stream Users) {}
+}
+
+message SystemInfo {
+    string system_id   = 1;
+    string board_model = 2;
+}
+
+message CertTypes {
+    repeated string types = 1;
+}
+
+message GetCertRequest {
+    string type   = 1;
+    bytes issuer  = 2;
+    string serial = 3;
+}
+
+message GetCertResponse {
+    string type     = 1;
+    string cert_url = 2;
+    string key_url  = 3;
+}
+
+message PermissionsRequest {
+    string secret               = 1;
+    string functional_server_id = 2;
+}
+
+message PermissionsResponse {
+    string service_id       = 1;
+    Permissions permissions = 2;
+}


### PR DESCRIPTION
GetCertTypes and GetCert commands moved to public service. It is required
to access TLS config for connection to protected service.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>