### PR TITLE
[sm] Change type of instance in InstanceIdent to int64

### DIFF
--- a/proto/servicemanager/v2/servicemanager.proto
+++ b/proto/servicemanager/v2/servicemanager.proto
@@ -84,7 +84,7 @@ message RunInstancesRequest {
 message InstanceIdent {
     string service_id = 1;
     string subject_id = 2;
-    uint64 instance   = 3;
+    int64 instance    = 3;
 }
 
 message InstanceStateRequest {


### PR DESCRIPTION
We need possibility to have subject_id and instance fields optional in
InstanceIdent message. If subject_id is empty it means absent. For instance
we will use -1 to indicate that field is absent.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>