### PR TITLE
Add message identification

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: WebKit
+ColumnLimit: 120
+FixNamespaceComments: true
+NamespaceIndentation: None
+Cpp11BracedListStyle: true
+AllowShortFunctionsOnASingleLine: InlineOnly
+AlwaysBreakTemplateDeclarations: Yes
+AlignConsecutiveMacros: true
+AlignConsecutiveDeclarations: true

--- a/vchanapi/vchanapi.h
+++ b/vchanapi/vchanapi.h
@@ -24,6 +24,8 @@ enum AosVChanSource {
 struct VChanMessageHeader {
     uint32_t mSource;
     uint32_t mDataSize;
+    uint64_t mRequestID;
+    char     mMethodName[256];
     uint8_t  mSha256[32];
 };
 #pragma pack(pop)

--- a/vchanapi/vchanapi.h
+++ b/vchanapi/vchanapi.h
@@ -25,6 +25,8 @@ struct VChanMessageHeader {
     uint32_t mSource;
     uint32_t mDataSize;
     uint64_t mRequestID;
+    int32_t  mErrno;
+    int32_t  mAosError;
     char     mMethodName[256];
     uint8_t  mSha256[32];
 };


### PR DESCRIPTION
Added the field mMethodName to identify which method is being called, as the data over vchan is just passed as an array of bytes. This is to understand what exactly the request is. Also, mRequestId is used in the response to identify which request the response corresponds to.