### PR TITLE
[iam] Move GetAPIVersion to separate IAMVersionService

### DIFF
--- a/proto/iamanager/v5/iamanager.proto
+++ b/proto/iamanager/v5/iamanager.proto
@@ -6,7 +6,6 @@ import "google/protobuf/empty.proto";
 import "common/v1/common.proto";
 
 service IAMPublicService {
-    rpc GetAPIVersion(google.protobuf.Empty) returns (APIVersion) {}
     rpc GetNodeInfo(google.protobuf.Empty) returns (NodeInfo) {}
     rpc GetCert(GetCertRequest) returns (GetCertResponse) {}
 }
@@ -48,10 +47,6 @@ service IAMCertificateService {
 service IAMPermissionsService {
     rpc RegisterInstance(RegisterInstanceRequest) returns (RegisterInstanceResponse) {}
     rpc UnregisterInstance(UnregisterInstanceRequest) returns (google.protobuf.Empty) {}
-}
-
-message APIVersion {
-    uint64 version = 1;
 }
 
 message PartitionInfo {

--- a/proto/iamanager/version.proto
+++ b/proto/iamanager/version.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package iamanager;
+
+import "google/protobuf/empty.proto";
+
+service IAMVersionService {
+    rpc GetAPIVersion(google.protobuf.Empty) returns (APIVersion) {}
+}
+
+message APIVersion {
+    uint64 version = 1;
+}


### PR DESCRIPTION
As we use version suffix for package name, it is hard for client to get current API version. Move GetAPIVersion RPC to separate IAMVersionService.